### PR TITLE
publish website nightly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish website
+
+on:
+  schedule:
+    - cron:  '0 0 * * *' # run nightly
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+    - run: npm install yarn@latest
+    - run: yarn install
+    - run: yarn download
+    - run: yarn dl2json
+
+    - name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@4.1.0
+      with:
+        branch: gh-pages # The branch the action should deploy to.
+        folder: docs # The folder the action should deploy.


### PR DESCRIPTION
Run build & publish website every night.

For this the Github pages settings need to be updated to point to the root of the gh-pages branch.

![github-pages-publish](https://user-images.githubusercontent.com/1335181/111922553-25002180-8aa3-11eb-8e5a-59c99d144e7f.PNG)
